### PR TITLE
Add support for --profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ with the directory as an option.
 lambda-uploader ./myfunc
 ```
 
+To specify an alternative profile that has been defined in `~/.aws/credentials` use the
+`--profile` parameter.
+```shell
+lambda-uploader --profile=alternative-profile
+```
+
 If you would prefer to upload another way you can tell the uploader to ignore the upload.
 This will create a package and leave it in the project directory.
 ```shell

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -60,7 +60,7 @@ def _execute(args):
 
     if not args.no_upload:
         _print('Uploading Package')
-        uploader.upload_package(pkg, cfg)
+        uploader.upload_package(pkg, cfg, args.profile)
         pkg.clean_zipfile()
 
     _print('Fin')
@@ -86,6 +86,8 @@ def main(arv=None):
                         action='store_const',
                         help='publish an upload to an immutable version',
                         const=True)
+    parser.add_argument('--profile', dest='profile',
+                        help='specify AWS cli profile')
     parser.add_argument('function_dir', default=getcwd(), nargs='?',
                         help='lambda function directory')
 

--- a/lambda_uploader/uploader.py
+++ b/lambda_uploader/uploader.py
@@ -18,11 +18,13 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-def upload_package(pkg, config):
+def upload_package(pkg, config, profile_name):
     with open(pkg.zip_file, "rb") as fil:
         zip_file = fil.read()
 
-    client = boto3.client('lambda', region_name=config.region)
+    session = boto3.session.Session(region_name=config.region,
+                                    profile_name=profile_name)
+    client = session.client('lambda')
     # Assume the function already exists in AWS
     existing_function = True
 


### PR DESCRIPTION
I have several profiles defined in `~/.aws/credentials`. The `aws` cli tool supports specifying which non-default profile should be used with the `--profile` parameter. This PR adds that same argument to lambda-uploader.