### PR TITLE
Ensure requirements array is really array

### DIFF
--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -75,7 +75,7 @@ class Package(object):
             LOG.debug("Installing requirements found %s in config"
                       % requirements)
             cmd = [os.path.join(self._pkg_venv, self._venv_pip),
-                   'install', " ".join(requirements)]
+                   'install'] + requirements
 
         elif os.path.isfile("requirements.txt"):
             # Pip install


### PR DESCRIPTION
This was passing a giant string of requirements to pip, as a single token. Now we pass each requirement as its own token.

Fixes #17.