### PR TITLE
Only cache specific dirs, work around PYTHONPATH using setup.py

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+  pre:
+    - rm -r ~/virtualenvs
+
 machine:
   python:
     version: 2.7
@@ -5,6 +9,7 @@ machine:
 test:
   pre:
     - pip install -r test-requirements.txt
+    - python setup.py develop
   override:
     - flake8 .
     - py.test


### PR DESCRIPTION
- Remove virtualenvs so they won't be cached, and cause conflicts
- Setup this module in develop mode, so that tests can legally do `from lambda_uploader import ...`