### PR TITLE
Add --config to override lambda.json path

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -24,10 +24,10 @@ DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
 
 
 class Config(object):
-    def __init__(self, pth):
+    def __init__(self, pth, config_file=None):
         self._path = pth
         self._config = None
-        self._load_config()
+        self._load_config(config_file)
         self._set_defaults()
 
         for param, clss in REQUIRED_PARAMS.iteritems():
@@ -81,12 +81,14 @@ class Config(object):
                                     % (key, cls, type(self._config[key])))
 
     '''Load config ... called by init()'''
-    def _load_config(self):
-        config_file = path.join(self._path, 'lambda.json')
-        if not path.isfile(config_file):
-            raise Exception("lambda.json not found")
+    def _load_config(self, lambda_file=None):
+        if not lambda_file:
+            lambda_file = path.join(self._path, 'lambda.json')
 
-        with open(config_file) as config_file:
+        if not path.isfile(lambda_file):
+            raise Exception("%s not found" % lambda_file)
+
+        with open(lambda_file) as config_file:
             self._config = json.load(config_file)
 
     def __getattr__(self, key):

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -47,7 +47,7 @@ def _print(txt):
 def _execute(args):
     pth = path.abspath(args.function_dir)
 
-    cfg = config.Config(pth)
+    cfg = config.Config(pth, args.config)
 
     _print('Building Package')
     pkg = package.build_package(pth, cfg.requirements)
@@ -89,7 +89,6 @@ def main(arv=None):
     parser.add_argument('--no-upload', dest='no_upload',
                         action='store_const', help='dont upload the zipfile',
                         const=True)
-
     parser.add_argument('--no-clean', dest='no_clean',
                         action='store_const',
                         help='dont cleanup the temporary workspace',
@@ -105,6 +104,8 @@ def main(arv=None):
                         default=None, help=alias_help)
     parser.add_argument('--alias-description', '-m', dest='alias_description',
                         default=None, help='alias description')
+    parser.add_argument('--config', help='Overrides lambda.json',
+                        default=None)
     parser.add_argument('function_dir', default=getcwd(), nargs='?',
                         help='lambda function directory')
 


### PR DESCRIPTION
My current use-case includes multiple lambda handlers for the same set of files.