### PR TITLE
Added a role flag

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -24,10 +24,12 @@ DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
 
 
 class Config(object):
-    def __init__(self, pth, config_file=None):
+    def __init__(self, pth, config_file=None, role=None):
         self._path = pth
         self._config = None
         self._load_config(config_file)
+        if role is not None:
+            self._config['role'] = role
         self._set_defaults()
 
         for param, clss in REQUIRED_PARAMS.iteritems():

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -22,7 +22,7 @@ import logging
 import traceback
 import lambda_uploader
 
-from os import getcwd, path
+from os import getcwd, path, getenv
 from lambda_uploader import package, config, uploader
 
 LOG = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ def _print(txt):
 def _execute(args):
     pth = path.abspath(args.function_dir)
 
-    cfg = config.Config(pth, args.config)
+    cfg = config.Config(pth, args.config, role=args.role)
 
     _print('Building Package')
     pkg = package.build_package(pth, cfg.requirements)
@@ -97,6 +97,10 @@ def main(arv=None):
                         action='store_const',
                         help='publish an upload to an immutable version',
                         const=True)
+    parser.add_argument('--role', dest='role',
+                        default=getenv('LAMBDA_UPLOADER_ROLE'),
+                        help=('IAM role to assign the lambda function, '
+                              'can be set with $LAMBDA_UPLOADER_ROLE'))
     parser.add_argument('--profile', dest='profile',
                         help='specify AWS cli profile')
     alias_help = 'alias for published version (WILL SET THE PUBLISH FLAG)'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -17,6 +17,13 @@ def test_load_config():
         assert cfg.raw[key] == val
 
 
+def test_role_override():
+    role = 'arn:aws:iam::00000000000:role/myfunc_role'
+    cfg = config.Config(EX_CONFIG, role=role)
+
+    assert cfg.role is role
+
+
 def test_set_publish():
     cfg = config.Config(EX_CONFIG)
     # Check that we default to false


### PR DESCRIPTION
This allows publishing a lambda function without needing to publish the role in the config.  By default the flag will read the environment variable LAMBDA_UPLOADER_ROLE which can be set in CI to make full CD easier.