### PR TITLE
Allow use of existing virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ To specify an alternative profile that has been defined in `~/.aws/credentials` 
 lambda-uploader --profile=alternative-profile
 ```
 
+To specify an alternative, prexisting virtualenv use the `--virtualenv` parameter.
+```shell
+lambda-uploader --virtualenv=~/.virtualenv/my_custom_virtualenv
+```
+
 If you would prefer to upload another way you can tell the uploader to ignore the upload.
 This will create a package and leave it in the project directory.
 ```shell

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,12 @@ To specify an alternative profile that has been defined in
 
     lambda-uploader --profile=alternative-profile
 
+To specify an alternative, prexisting virtualenv use the ``--virtualenv`` parameter.
+
+.. code:: shell
+
+    lambda-uploader --virtualenv=~/.virtualenv/my_custom_virtualenv
+
 If you would prefer to upload another way you can tell the uploader to
 ignore the upload. This will create a package and leave it in the
 project directory.

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -50,7 +50,7 @@ def _execute(args):
     cfg = config.Config(pth, args.config, role=args.role)
 
     _print('Building Package')
-    pkg = package.build_package(pth, cfg.requirements)
+    pkg = package.build_package(pth, cfg.requirements, args.virtualenv)
 
     if not args.no_clean:
         pkg.clean_workspace()
@@ -97,6 +97,9 @@ def main(arv=None):
                         action='store_const',
                         help='publish an upload to an immutable version',
                         const=True)
+    parser.add_argument('--virtualenv', '-e',
+                        help='use specified virtualenv instead of making one',
+                        default=None)
     parser.add_argument('--role', dest='role',
                         default=getenv('LAMBDA_UPLOADER_ROLE'),
                         help=('IAM role to assign the lambda function, '

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -39,6 +39,7 @@ def test_prepare_workspace():
 
     pkg = package.Package(TESTING_TEMP_DIR)
     pkg.prepare_workspace()
+    pkg.prepare_virtualenv()
     assert path.isdir(temp_workspace)
     assert path.isdir(path.join(temp_workspace, 'venv'))
     if sys.platform == 'win32' or sys.platform == 'cygwin':
@@ -61,6 +62,11 @@ def test_install_requirements():
         site_packages = path.join(temp_workspace, "venv\\lib\\site-packages")
 
     assert path.isdir(path.join(site_packages, '_pytest'))
+
+
+def test_existing_virtualenv():
+    pkg = package.Package(TESTING_TEMP_DIR, 'abc')
+    assert pkg._pkg_venv == 'abc'
 
 
 def test_package():


### PR DESCRIPTION
- Allow user to specify a virtualenv to use instead of building one, fixes #26.
- Add test to be sure a supplied virtualenv is used