### PR TITLE
Add --no-virtualenv flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ To specify an alternative, prexisting virtualenv use the `--virtualenv` paramete
 lambda-uploader --virtualenv=~/.virtualenv/my_custom_virtualenv
 ```
 
+To omit using a virtualenv use the `--no-virtualenv` parameter.
+```shell
+lambda-uploader --no-virtualenv
+```
+
 If you would prefer to upload another way you can tell the uploader to ignore the upload.
 This will create a package and leave it in the project directory.
 ```shell

--- a/README.rst
+++ b/README.rst
@@ -64,11 +64,18 @@ To specify an alternative profile that has been defined in
 
     lambda-uploader --profile=alternative-profile
 
-To specify an alternative, prexisting virtualenv use the ``--virtualenv`` parameter.
+To specify an alternative, prexisting virtualenv use the
+``--virtualenv`` parameter.
 
 .. code:: shell
 
     lambda-uploader --virtualenv=~/.virtualenv/my_custom_virtualenv
+
+To omit using a virtualenv use the ``--no-virtualenv`` parameter.
+
+.. code:: shell
+
+    lambda-uploader --no-virtualenv
 
 If you would prefer to upload another way you can tell the uploader to
 ignore the upload. This will create a package and leave it in the

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -49,9 +49,19 @@ def _execute(args):
 
     cfg = config.Config(pth, args.config, role=args.role)
 
+    if args.no_virtualenv:
+        # specified flag to omit entirely
+        venv = False
+    elif args.virtualenv:
+        # specified a custom virtualenv
+        venv = args.virtualenv
+    else:
+        # build and include virtualenv, the default
+        venv = None
+
     _print('Building Package')
     pkg = package.build_package(pth, cfg.requirements,
-                                args.virtualenv, cfg.ignore)
+                                venv, cfg.ignore)
 
     if not args.no_clean:
         pkg.clean_workspace()
@@ -101,6 +111,10 @@ def main(arv=None):
     parser.add_argument('--virtualenv', '-e',
                         help='use specified virtualenv instead of making one',
                         default=None)
+    parser.add_argument('--no-virtualenv', dest='no_virtualenv',
+                        action='store_const',
+                        help='do not create or include a virtualenv at all',
+                        const=True)
     parser.add_argument('--role', dest='role',
                         default=getenv('LAMBDA_UPLOADER_ROLE'),
                         help=('IAM role to assign the lambda function, '


### PR DESCRIPTION
- Add a --no-virtualenv flag so that we can omit a virtualenv entirely, if desired
- If no requirements are given (via config file or missing requirements.txt), also omit making a virtualenv
- Rename original #prepare_virtualenv to #build_new_virtualenv to better reflect that it always tries to make a virtualenv
- Refactor virtualenv logic out of #build_package into its own #prepare_virtualenv method
- Add tests for new possible inputs, and also ensure build and prepare raise an exception when given invalid inputs

Closes #31.