### PR TITLE
Add check for Python 2.7 - bail if not found

### DIFF
--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -91,6 +91,10 @@ def _execute(args):
 
 def main(arv=None):
     """lambda-uploader command line interface."""
+    # Check for Python 2.7 (required for Lambda)
+    if not (sys.version_info[0] == 2 and sys.version_info[1] == 7):
+        raise RuntimeError('lambda-uploader requires Python 2.7')
+
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=DEPENDENCIES,
     packages=find_packages(exclude=['tests']),
     classifiers=[
-        "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
     ],
     license=_lu_meta['license'],


### PR DESCRIPTION
Prevent a nufty like me wasting 30 minutes figuring out why Python 2.6 doesn't work with lambda-uploader!