### PR TITLE
Look for requirements.txt in function_dir

### DIFF
--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -71,8 +71,9 @@ class Package(object):
         os.mkdir(self._temp_workspace)
 
     def prepare_virtualenv(self):
+        requirements_file = os.path.join(self._path, "requirements.txt")
         requirements_exist = \
-            self._requirements or os.path.isfile("requirements.txt")
+            self._requirements or os.path.isfile(requirements_file)
         if self._virtualenv and self._virtualenv is not False:
             if not os.path.isdir(self._virtualenv):
                 raise Exception("virtualenv %s not found" % self._virtualenv)
@@ -125,11 +126,12 @@ class Package(object):
             cmd = [os.path.join(self._pkg_venv, self._venv_pip),
                    'install'] + self._requirements
 
-        elif os.path.isfile("requirements.txt"):
+        elif os.path.isfile(os.path.join(self._path, "requirements.txt")):
             # Pip install
             LOG.debug("Installing requirements from requirements.txt file")
             cmd = [os.path.join(self._pkg_venv, self._venv_pip),
-                   "install", "-r", "requirements.txt"]
+                   "install", "-r",
+                   os.path.join(self._path, "requirements.txt")]
 
         if cmd is not None:
             prc = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -38,7 +38,8 @@ def test_prepare_workspace():
     temp_workspace = path.join(TESTING_TEMP_DIR,
                                package.TEMP_WORKSPACE_NAME)
 
-    pkg = package.Package(TESTING_TEMP_DIR)
+    reqs = ['pytest']
+    pkg = package.Package(TESTING_TEMP_DIR, requirements=reqs)
     pkg.prepare_workspace()
     pkg.prepare_virtualenv()
     assert path.isdir(temp_workspace)
@@ -68,7 +69,8 @@ def test_install_requirements():
 def test_default_virtualenv():
     temp_workspace = path.join(TESTING_TEMP_DIR,
                                package.TEMP_WORKSPACE_NAME)
-    pkg = package.Package(TESTING_TEMP_DIR)
+    reqs = ['pytest']
+    pkg = package.Package(TESTING_TEMP_DIR, requirements=reqs)
     pkg.prepare_virtualenv()
     # ensure we picked a real venv path if using default behavior
     assert pkg._pkg_venv == ("%s/venv" % temp_workspace)


### PR DESCRIPTION
Hey guys,

Currently if you use lambda-uploader like so:

`lambda-uploader /path/to/function/dir`

lambda-uploader only looks for `requirements.txt` in the path it is executed from, not the `function_dir`.

This PR changes lambda-uploader to look for requirements.txt in the `function_dir` (if provided) instead of in the current directory which seems like how it should work. Right?

Also, the tests were kind of cheating because the `prepare_virtualenv` function was finding lambda-uploader's `requirements.txt` in the virtualenv tests and creating virtualenvs even though it wasn't explicitly stated. With the change to looking for `requirements.txt` in `function_dir` these tests broke and needed updating.

Thanks for making this tool - absolutely awesome! :smile: 