### PR TITLE
Match ignores against paths relative to the source dir

### DIFF
--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -149,6 +149,14 @@ class Package(object):
                 raise Exception('pip returned unsuccessfully')
 
     def package(self, ignore=[]):
+        """
+        Create a zip file of the lambda script and its dependencies.
+
+        :param list ignore: a list of regular expression strings to match paths
+            of files in the source of the lambda script against and ignore
+            those files when creating the zip file. The paths to be matched are
+            local to the source root.
+        """
         package = os.path.join(self._temp_workspace, 'lambda_package')
 
         # Copy site packages into package base
@@ -168,8 +176,8 @@ class Package(object):
                 LOG.info('Copying lib64 site packages')
                 utils.copy_tree(lib64_path, package)
 
-        # Append the temp workspace to the ignore list
-        ignore.append("^%s/*" % self._temp_workspace)
+        # Append the temp workspace to the ignore list:
+        ignore += ["^%s/*" % TEMP_WORKSPACE_NAME]
         utils.copy_tree(self._path, package, ignore)
         self._create_zip(package)
 

--- a/lambda_uploader/utils.py
+++ b/lambda_uploader/utils.py
@@ -27,7 +27,8 @@ def copy_tree(src, dest, ignore=[]):
     for root, _, files in os.walk(src):
         for filename in files:
             path = os.path.join(root, filename)
-            if _ignore_file(path, ignore):
+            path_relative_to_the_source_dir = os.path.relpath(path, src)
+            if _ignore_file(path_relative_to_the_source_dir, ignore):
                 continue
 
             sub_dirs = os.path.dirname(os.path.relpath(path,

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -31,7 +31,7 @@ def test_package_clean_workspace():
 
     pkg = package.Package(TESTING_TEMP_DIR)
     pkg.clean_workspace()
-    assert path.isdir(temp_workspace) == False
+    assert path.isdir(temp_workspace) is False
 
 
 def test_prepare_workspace():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,14 +7,25 @@ from lambda_uploader import utils
 TESTING_TEMP_DIR = '.testing_temp'
 
 TEST_TREE = [
-        'foo.py',
-        'bar/foo.py',
-        'bar/bar/foo.py',
-        'ignore/foo.py'
-        'ignore-me.py'
-        ]
+    'foo.py',
+    'bar/foo.py',
+    'bar/bar/foo.py',
+    'ignore/foo.py',
+    'ignore-me.py',
+]
+PATHS_TO_BE_IGNORED = [
+    'ignore/foo.py',
+    'ignore-me.py',
+]
 
-TEST_IGNORE = ['ignore/*', 'ignore-me.py']
+TEST_IGNORE = [
+    'ignore/*',
+    'ignore-me.py',
+    # The one below would exclude all the files if files to be ignored were
+    # matched based on the full path, rather than the path relative to the
+    # source directory, since the source directory contains 'test' in its path.
+    'test',
+]
 
 
 def test_copy_tree():
@@ -31,10 +42,7 @@ def test_copy_tree():
     utils.copy_tree(TESTING_TEMP_DIR, copy_dir, TEST_IGNORE)
     for fil in TEST_TREE:
         pth = path.join(copy_dir, fil)
-        if utils._ignore_file(fil, TEST_IGNORE):
-            assert path.isfile(pth) is not True
-        else:
-            assert path.isfile(pth)
+        assert path.isfile(pth) is (fil not in PATHS_TO_BE_IGNORED)
 
     rmtree(TESTING_TEMP_DIR)
     rmtree(copy_dir)


### PR DESCRIPTION
Previously using a string like 'home' in ignores could cause all source files to be ignored because their absolute paths would likely all begin with '/home'.