### PR TITLE
fix for google.protobuf install

### DIFF
--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -176,6 +176,12 @@ class Package(object):
                 LOG.info('Copying lib64 site packages')
                 utils.copy_tree(lib64_path, package)
 
+        #AWS Lambda has issues with the normal protobuf install lacking a root level __init__.py
+        protobuf_install_dir = os.path.join(package,'google')
+        protobuf_init_file = os.path.join(protobuf_install_dir,'__init__.py')
+        if os.path.exists(protobuf_install_dir) and not os.path.exists(protobuf_init_file):
+            open(protobuf_init_file, 'a').close()
+
         # Append the temp workspace to the ignore list:
         ignore += ["^%s/*" % TEMP_WORKSPACE_NAME]
         utils.copy_tree(self._path, package, ignore)


### PR DESCRIPTION
When trying to use google.protobuf module in the python Lambda function, it fails with:
`"Unable to import module 'lambda_function': No module named google.protobuf" `

The reason is that 'google' directory is not being treated as python module, because it lacks `__init__.py` file.
Explanation from https://github.com/awslabs/kinesis-deaggregation/tree/master/python:
 `Google protobuf module normally relies on using a Python pth setting to make the root google module importable`. To fix you just need to create missing file.

This hacky fix is copy-paste from:
https://github.com/awslabs/kinesis-deaggregation/blob/master/python/make_lambda_build.py#L111