### PR TITLE
Match setup.py deps with requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-boto3==1.1.4
+boto3==1.2.2
+virtualenv

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ DEPENDENCIES = [
     'virtualenv',
 ]
 
-TESTS_REQUIRE = []
+TESTS_REQUIRE = [
+    'pylint==1.4.1',
+    'flake8==2.3.0',
+    'pytest==2.8.2',
+]
 
 
 def package_meta():


### PR DESCRIPTION
We had a mismatch of requirements.txt and setup.py with respect to the boto3 version.