### PR TITLE
Allow the specification of the Function Path using the config

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -21,7 +21,7 @@ REQUIRED_PARAMS = {u'name': basestring, u'description': basestring,
 
 DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
                   u'alias': None, u'alias_description': None,
-                  u'ignore': []}
+                  u'ignore': [], u'function_path': ''}
 
 
 class Config(object):

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -60,6 +60,8 @@ def _execute(args):
         venv = None
 
     _print('Building Package')
+    if cfg.function_path:
+        pth = cfg.function_path
     pkg = package.build_package(pth, cfg.requirements,
                                 venv, cfg.ignore)
 


### PR DESCRIPTION
This allows you to store the configuration file separate from the
actual Lambda function.