### PR TITLE
Allow adding any other extra files in a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ To omit using a virtualenv use the `--no-virtualenv` parameter.
 lambda-uploader --no-virtualenv
 ```
 
+To inject any other additional files, use the `--extra-file EXTRA_FILE` parameter.
+```shell
+lambda-uploader --extra-file ~/stuff_for_lambda_packages
+```
+
 If you would prefer to upload another way you can tell the uploader to ignore the upload.
 This will create a package and leave it in the project directory.
 ```shell

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ To omit using a virtualenv use the ``--no-virtualenv`` parameter.
 
     lambda-uploader --no-virtualenv
 
+To inject any other additional files, use the ``--extra-file EXTRA_FILE`` parameter.
+
+.. code:: shell
+
+    lambda-uploader --extra-file ~/stuff_for_lambda_packages
+
 If you would prefer to upload another way you can tell the uploader to
 ignore the upload. This will create a package and leave it in the
 project directory.

--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -48,6 +48,7 @@ class Package(object):
         self._virtualenv = None
         self._skip_virtualenv = False
         self._requirements = None
+        self._extra_files = []
 
     def build(self, ignore=[]):
         '''Calls all necessary methods to build the Lambda Package'''
@@ -105,6 +106,12 @@ class Package(object):
             # use supplied virtualenv path
             self._pkg_venv = self._virtualenv
             self._skip_virtualenv = True
+
+    def extra_file(self, element):
+        '''
+        Sets an additional file or path that we copy into the resulting package
+        '''
+        self._extra_files.append(element)
 
     def install_dependencies(self):
         ''' Creates a virtualenv and installs requirements '''
@@ -215,6 +222,15 @@ class Package(object):
             if not os.path.islink(lib64_path):
                 LOG.info('Copying lib64 site packages')
                 utils.copy_tree(lib64_path, package)
+
+        for p in self._extra_files:
+            LOG.info('Copying extra %s into package' % p)
+            if os.path.isdir(p):
+                utils.copy_tree(p, package)
+                ignore += ["^%s/*" % p]
+            else:
+                shutil.copy(p, package)
+                ignore += ["%s" % p]
 
         # Append the temp workspace to the ignore list:
         ignore += ["^%s/*" % TEMP_WORKSPACE_NAME]

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -60,6 +60,8 @@ def _execute(args):
         venv = None
 
     _print('Building Package')
+    for p in args.extra_files:
+        package.extra_file(p)
     if cfg.function_path:
         pth = cfg.function_path
     pkg = package.build_package(pth, cfg.requirements,
@@ -117,6 +119,10 @@ def main(arv=None):
     parser.add_argument('--virtualenv', '-e',
                         help='use specified virtualenv instead of making one',
                         default=None)
+    parser.add_argument('--extra-files', '-x',
+                        action='append',
+                        help='include file or directory path in package',
+                        default=[])
     parser.add_argument('--no-virtualenv', dest='no_virtualenv',
                         action='store_const',
                         help='do not create or include a virtualenv at all',

--- a/test/dummyfile
+++ b/test/dummyfile
@@ -1,0 +1,1 @@
+dummy data

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -7,6 +7,8 @@ from os import path
 from lambda_uploader import package
 
 TESTING_TEMP_DIR = '.testing_temp'
+WORKING_TEMP_DIR = path.join(TESTING_TEMP_DIR, '.lambda_uploader_temp')
+PACKAGE_TEMP_DIR = path.join(WORKING_TEMP_DIR, 'lambda_package')
 
 
 def setup_module(module):
@@ -105,6 +107,21 @@ def test_package():
     pkg = package.Package(TESTING_TEMP_DIR)
     pkg.package()
     assert path.isfile(path.join(TESTING_TEMP_DIR, 'lambda_function.zip'))
+
+
+def test_package_with_extras():
+    pkg = package.Package(TESTING_TEMP_DIR)
+    pkg.extra_file(path.join('test', 'extra'))
+    pkg.extra_file(path.join('test', 'dummyfile'))
+    pkg.package()
+
+    # test a single file
+    expected_extra_file1 = path.join(PACKAGE_TEMP_DIR, 'dummyfile')
+    assert path.isfile(expected_extra_file1)
+
+    # test a recursive directory
+    expected_extra_file2 = path.join(PACKAGE_TEMP_DIR, 'foo/__init__.py')
+    assert path.isfile(expected_extra_file2)
 
 
 def test_package_name():


### PR DESCRIPTION
Introduce a new commandline option `--extra-path`; when supplied, lambda-uploader will copy any additional files from that path directly into the final package. This could be used to inject standard files (e.g. LICENSE, logo.jpg, etc) or to insert a missing `__init__.py` from some module that changes the python import path (e.g. [google.protobuf](https://github.com/awslabs/kinesis-deaggregation/blob/master/python/make_lambda_build.py#L111)).

RE: #52