### PR TITLE
fixes a bug in the shell relating to extra files

### DIFF
--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -60,9 +60,6 @@ def _execute(args):
         venv = None
 
     _print('Building Package')
-    for p in args.extra_files:
-        package.extra_file(p)
-
     requirements = cfg.requirements
     if args.requirements:
         requirements = path.abspath(args.requirements)


### PR DESCRIPTION
why
---
extra files are being added to the ```package``` package rather than the ```pkg``` package in the shell script.

what
---
removes lines that seem unnecessary now that the ```build_package``` function is aware of extra files

