### PR TITLE
Copy parent on --extra-files directories

### DIFF
--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -228,12 +228,11 @@ class Package(object):
 
         for p in self._extra_files:
             LOG.info('Copying extra %s into package' % p)
+            ignore += ["%s" % p]
             if os.path.isdir(p):
-                utils.copy_tree(p, package)
-                ignore += ["^%s/*" % p]
+                utils.copy_tree(p, package, include_parent=True)
             else:
                 shutil.copy(p, package)
-                ignore += ["%s" % p]
 
         # Append the temp workspace to the ignore list:
         ignore += ["^%s/*" % TEMP_WORKSPACE_NAME]

--- a/lambda_uploader/utils.py
+++ b/lambda_uploader/utils.py
@@ -21,8 +21,18 @@ import re
 LOG = logging.getLogger(__name__)
 
 
-def copy_tree(src, dest, ignore=[]):
+def copy_tree(src, dest, ignore=[], include_parent=False):
+    if os.path.isfile(src):
+        raise Exception('Cannot use copy_tree with a file as the src')
+
     LOG.info('Copying source files')
+    if include_parent:
+        # if src is foo, make dest/foo and copy files there
+        nested_dest = os.path.join(dest, os.path.basename(src))
+        os.makedirs(nested_dest)
+    else:
+        nested_dest = dest
+
     # Re-create directory structure
     for root, _, files in os.walk(src):
         for filename in files:
@@ -33,7 +43,7 @@ def copy_tree(src, dest, ignore=[]):
 
             sub_dirs = os.path.dirname(os.path.relpath(path,
                                                        start=src))
-            pkg_path = os.path.join(dest, sub_dirs)
+            pkg_path = os.path.join(nested_dest, sub_dirs)
             if not os.path.isdir(pkg_path):
                 os.makedirs(pkg_path)
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -120,7 +120,7 @@ def test_package_with_extras():
     assert path.isfile(expected_extra_file1)
 
     # test a recursive directory
-    expected_extra_file2 = path.join(PACKAGE_TEMP_DIR, 'foo/__init__.py')
+    expected_extra_file2 = path.join(PACKAGE_TEMP_DIR, 'extra/foo/__init__.py')
     assert path.isfile(expected_extra_file2)
 
 


### PR DESCRIPTION
When `--extra-files` is passed a directory foo, we'll now copy `foo` along with everything inside it.

Fixes #63.