### PR TITLE
Allow extra_files to be specified in config file

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -21,7 +21,7 @@ REQUIRED_PARAMS = {u'name': basestring, u'description': basestring,
 
 DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
                   u'alias': None, u'alias_description': None,
-                  u'ignore': []}
+                  u'ignore': [], u'extra_files': []}
 
 
 class Config(object):

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -63,8 +63,11 @@ def _execute(args):
     requirements = cfg.requirements
     if args.requirements:
         requirements = path.abspath(args.requirements)
+    extra_files = cfg.extra_files
+    if args.extra_files:
+        extra_files = args.extra_files
     pkg = package.build_package(pth, requirements,
-                                venv, cfg.ignore, args.extra_files)
+                                venv, cfg.ignore, extra_files)
 
     if not args.no_clean:
         pkg.clean_workspace()


### PR DESCRIPTION
Changes to extend the "extra_files" functionality to the config file.  Behaviour based on "requirements" files, where command line options override what's in the config file.