### PR TITLE
Extend with VpcConfig support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ lambda-uploader CHANGELOG
   variables in favor of calling setter methods.
 - Add -c shorthand to the --config flag
 - Fixed the ignores to match against paths relative to the source dir
+- Added support for placing your lambda functions in specific VPC 
+  subnets and security groups
 
 0.5.1
 -----

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The lambda uploader expects a directory with, at a minimum, your lambda function
 and a lambda.json file.  It is not necessary to set requirements in your config
 file since the lambda uploader will also check for and use a requirements.txt file.
 
+Please note that you can leave the "vpc" object out of your config if you want your
+lambda function to use your default VPC and subnets. If you wish to use your lambda
+function inside a specific VPC, make sure you set up the role correctly to allow this.
+
 Example lambda.json file:
 ```json
 {
@@ -35,7 +39,15 @@ Example lambda.json file:
     "/*.pyc"
   ],
   "timeout": 30,
-  "memory": 512
+  "memory": 512,
+  "vpc": {
+    "subnets": [
+      "subnet-00000000"
+    ],
+    "security_groups": [
+      "sg-00000000"
+    ]
+  }
 }
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ function and a lambda.json file. It is not necessary to set requirements
 in your config file since the lambda uploader will also check for and
 use a requirements.txt file.
 
+Please note that you can leave the "vpc" object out of your config if you want your
+lambda function to use your default VPC and subnets. If you wish to use your lambda
+function inside a specific VPC, make sure you set up the role correctly to allow this.
+
 Example lambda.json file:
 
 .. code:: json
@@ -48,7 +52,15 @@ Example lambda.json file:
         "/*.pyc"
       ],
       "timeout": 30,
-      "memory": 512
+      "memory": 512,
+      "vpc": {
+        "subnets": [
+          "subnet-00000000"
+        ],
+        "security_groups": [
+          "sg-00000000"
+        ]
+      }
     }
 
 Command Line Usage

--- a/test/configs/lambda-no-vpc.json
+++ b/test/configs/lambda-no-vpc.json
@@ -1,0 +1,15 @@
+{
+  "name": "myFunc",
+  "description": "myfunc",
+  "region": "us-east-1",
+  "handler": "function.lambda_handler",
+  "role": "arn:aws:iam::00000000000:role/lambda_basic_execution",
+  "requirements": ["Jinja2==2.8"],
+  "ignore": [
+    "circle.yml",
+    ".git",
+    "/*.pyc"
+  ],
+  "timeout": 30,
+  "memory": 512
+}

--- a/test/configs/lambda.json
+++ b/test/configs/lambda.json
@@ -1,0 +1,23 @@
+{
+  "name": "myFunc",
+  "description": "myfunc",
+  "region": "us-east-1",
+  "handler": "function.lambda_handler",
+  "role": "arn:aws:iam::00000000000:role/lambda_basic_execution",
+  "requirements": ["Jinja2==2.8"],
+  "ignore": [
+    "circle.yml",
+    ".git",
+    "/*.pyc"
+  ],
+  "timeout": 30,
+  "memory": 512,
+  "vpc": {
+    "subnets": [
+      "subnet-00000000"
+    ],
+    "security_groups": [
+      "sg-00000000"
+    ]
+  }
+}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ from os import path
 from lambda_uploader import config
 
 EX_CONFIG = path.normpath(path.join(path.dirname(__file__),
-                          '../example'))
+                          '../test/configs'))
 
 
 def test_load_config():
@@ -22,6 +22,29 @@ def test_role_override():
     cfg = config.Config(EX_CONFIG, role=role)
 
     assert cfg.role is role
+
+
+def test_vpc_config():
+    subnet = 'subnet-00000000'
+    securitygroup = 'sg-00000000'
+    vpc = {
+        'subnets': [
+            subnet
+        ],
+        'security_groups': [
+            securitygroup
+        ]
+    }
+    cfg = config.Config(EX_CONFIG)
+
+    assert cfg.raw['vpc']['security_groups'][0] == vpc['security_groups'][0]
+    assert cfg.raw['vpc']['subnets'][0] == vpc['subnets'][0]
+
+
+def test_no_vpc():
+    cfg = config.Config(EX_CONFIG, EX_CONFIG + '/lambda-no-vpc.json')
+
+    assert cfg.raw['vpc'] is None
 
 
 def test_set_publish():


### PR DESCRIPTION
Because of firewall reasons I wanted to have my lambda functions land in specific subnets, with a specific security group. This PR supplies that functionality.