### PR TITLE
Added ability to upload to S3 instead of lambda directly

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -22,7 +22,8 @@ REQUIRED_VPC_PARAMS = {u'subnets': list, u'security_groups': list}
 
 DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
                   u'alias': None, u'alias_description': None,
-                  u'ignore': [], u'extra_files': [], u'vpc': None}
+                  u'ignore': [], u'extra_files': [], u'vpc': None,
+                  u's3_bucket': None, u's3_key': None}
 
 
 class Config(object):
@@ -59,6 +60,14 @@ class Config(object):
             return self._config['description']
         else:
             return self._config['alias_description']
+
+    '''
+    Public method to set the S3 bucket and keyname
+    '''
+    def set_s3(self, bucket, key=None):
+        self._config['s3_bucket'] = bucket
+        if key:
+            self._config['s3_key'] = key
 
     '''Set the publish attr to true'''
     def set_publish(self):
@@ -105,6 +114,11 @@ class Config(object):
                 raise TypeError("Config value '%s' should be %s not %s"
                                 % (key, cls, type(value)))
 
+    def s3_package_name(self):
+        if self._config.get('s3_key'):
+            return self.s3_key
+        return self.name + '.zip'
+
     '''Load config ... called by init()'''
     def _load_config(self, lambda_file=None):
         if not lambda_file:
@@ -117,8 +131,7 @@ class Config(object):
             self._config = json.load(config_file)
 
     def __getattr__(self, key):
-        val = self._config.get(key)
-        if val is not None:
-            return val
+        if key in self._config:
+            return self._config[key]
         else:
             return object.__getattribute__(self, key)

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -49,6 +49,9 @@ def _execute(args):
 
     cfg = config.Config(pth, args.config, role=args.role)
 
+    if args.s3_bucket:
+        cfg.set_s3(args.s3_bucket, args.s3_key)
+
     if args.no_virtualenv:
         # specified flag to omit entirely
         venv = False
@@ -142,6 +145,12 @@ def main(arv=None):
                         default=None, help=alias_help)
     parser.add_argument('--alias-description', '-m', dest='alias_description',
                         default=None, help='alias description')
+    parser.add_argument('--s3-bucket', '-s', dest='s3_bucket',
+                        help='S3 bucket to store the lambda function in',
+                        default=None)
+    parser.add_argument('--s3-key', '-k', dest='s3_key',
+                        help='Key name of the lambda function s3 object',
+                        default=None)
     parser.add_argument('--config', '-c', help='Overrides lambda.json',
                         default='lambda.json')
     parser.add_argument('function_dir', default=getcwd(), nargs='?',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ TESTS_REQUIRE = [
     'pylint==1.4.1',
     'flake8==2.3.0',
     'pytest==2.8.2',
+    'moto==0.4.23',
 ]
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pylint==1.4.1
 flake8==2.3.0
 pytest==2.8.2
+moto==0.4.23

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -54,3 +54,9 @@ def test_set_publish():
 
     cfg.set_publish()
     assert cfg.publish
+
+
+def test___getattr__():
+    cfg = config.Config(EX_CONFIG, EX_CONFIG + '/lambda.json')
+    assert cfg.s3_bucket is None
+    assert cfg.name == 'myFunc'

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -1,0 +1,22 @@
+import boto3
+
+from os import path
+from lambda_uploader import uploader, config
+from moto import mock_s3
+
+EX_CONFIG = path.normpath(path.join(path.dirname(__file__),
+                          '../test/configs'))
+
+
+@mock_s3
+def test_s3_upload():
+    mock_bucket = 'mybucket'
+    conn = boto3.resource('s3')
+    conn.create_bucket(Bucket=mock_bucket)
+
+    conf = config.Config(path.dirname(__file__),
+                         config_file=path.join(EX_CONFIG, 'lambda.json'))
+    conf.set_s3(mock_bucket)
+    upldr = uploader.PackageUploader(conf, None)
+
+    upldr._upload_s3(path.join(path.dirname(__file__), 'dummyfile'))

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -20,3 +20,11 @@ def test_s3_upload():
     upldr = uploader.PackageUploader(conf, None)
 
     upldr._upload_s3(path.join(path.dirname(__file__), 'dummyfile'))
+
+    # fetch the contents back out, be sure we truly uploaded the dummyfile
+    retrieved_bucket = conn.Object(
+        mock_bucket,
+        conf.s3_package_name()
+        ).get()['Body']
+    found_contents = str(retrieved_bucket.read()).rstrip()
+    assert found_contents == 'dummy data'


### PR DESCRIPTION
This gives the caller the ability to upload a function to S3 first
and use that S3 package to create or update the lambda function. This
also fixes the config __getattr__ bug so it will now return the value so
long as the key is set.