### PR TITLE
fix TypeError when reqs are blank

### DIFF
--- a/test/test_package.py
+++ b/test/test_package.py
@@ -67,6 +67,22 @@ def test_install_requirements():
     assert path.isdir(path.join(site_packages, '_pytest'))
 
 
+def test_install_no_requirements():
+    temp_workspace = path.join(TESTING_TEMP_DIR,
+                               package.TEMP_WORKSPACE_NAME)
+
+    pkg = package.Package(TESTING_TEMP_DIR)
+    pkg.requirements([])
+    pkg.install_dependencies()
+
+    site_packages = path.join(temp_workspace,
+                              'venv/lib/python2.7/site-packages')
+    if sys.platform == 'win32' or sys.platform == 'cygwin':
+        site_packages = path.join(temp_workspace, "venv\\lib\\site-packages")
+
+    assert path.isdir(path.join(site_packages, '_pytest'))
+
+
 def test_default_virtualenv():
     temp_workspace = path.join(TESTING_TEMP_DIR,
                                package.TEMP_WORKSPACE_NAME)


### PR DESCRIPTION
https://github.com/rackerlabs/lambda-uploader/blob/2eaec5d64a89296f024955b742337f50e63ad1f7/lambda_uploader/package.py#L90-L91

```python
>>> self._requirements, self._requirements_file = None
    Traceback (most recent call last):
      File "<package.py>", line 91, in <module>
        self._requirements, self._requirements_file = None
    TypeError: 'NoneType' object is not iterable
```