### PR TITLE
Bump to latest CircleCI supported Python

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install -U pip
     - pip install -U tox tox-pyenv
-    - pyenv local 2.7.9 3.4.3 3.5.0
+    - pyenv local 2.7.10 3.4.3 3.5.0
 
 test:
   override:


### PR DESCRIPTION
2.7.10 of python is available standard on CircleCI, so bump to that.

The list of supported versions can be found at:
  https://circleci.com/docs/environment/#python

Fixes #85.