### PR TITLE
Not enforcing the role to be set in config

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -23,13 +23,13 @@ except NameError:
 
 REQUIRED_PARAMS = {u'name': basestring, u'description': basestring,
                    u'region': basestring, u'handler': basestring,
-                   u'role': basestring, u'timeout': int, u'memory': int}
+                   u'timeout': int, u'memory': int}
 REQUIRED_VPC_PARAMS = {u'subnets': list, u'security_groups': list}
 
 DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
                   u'alias': None, u'alias_description': None,
                   u'ignore': [], u'extra_files': [], u'vpc': None,
-                  u's3_bucket': None, u's3_key': None}
+                  u's3_bucket': None, u's3_key': None, u'role': None}
 
 
 class Config(object):


### PR DESCRIPTION
This allows anyone using the lambda-uploader for packaging to not
have to set the role config option or the --role cli argument.