### PR TITLE
Fix config defaults to match documentation.

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -26,7 +26,7 @@ REQUIRED_PARAMS = {u'name': basestring, u'description': basestring,
                    u'role': basestring, u'timeout': int, u'memory': int}
 REQUIRED_VPC_PARAMS = {u'subnets': list, u'security_groups': list}
 
-DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
+DEFAULT_PARAMS = {u'requirements': u'requirements.txt', u'publish': False,
                   u'alias': None, u'alias_description': None,
                   u'ignore': [], u'extra_files': [], u'vpc': None,
                   u's3_bucket': None, u's3_key': None}


### PR DESCRIPTION
The module documentation says:

> It is not necessary to set requirements in your config file since the lambda uploader will also check for and use a requirements.txt file.

This is however not actually the default behavior. Actual default behavior is an empty list of requirements, which causes package.py to ignore requirements.txt.