### PR TITLE
Ignore the Parent directory of a file if it already exists

### DIFF
--- a/lambda_uploader/utils.py
+++ b/lambda_uploader/utils.py
@@ -28,8 +28,10 @@ def copy_tree(src, dest, ignore=[], include_parent=False):
     LOG.info('Copying source files')
     if include_parent:
         # if src is foo, make dest/foo and copy files there
-        nested_dest = os.path.join(dest, os.path.basename(src))
-        os.makedirs(nested_dest)
+        nested_dest = os.path.normpath(
+                os.path.join(dest, os.path.basename(src)))
+        if not os.path.isdir(nested_dest):
+            os.makedirs(nested_dest)
     else:
         nested_dest = dest
 


### PR DESCRIPTION
This primarily happens when using the extra files directive which has
include_parent set. Whenever extra files might look like ['dir/file1',
'dir/file2'] lambda-uploader will blow up on the second file because the
directory already exists.