### PR TITLE
Uploading non-python functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,9 @@ function description will be used when an alias-description is not provided.
 ```shell
 lambda-uploader --alias myAlias --alias-description 'My alias description' ./myfunc
 ```
+
+If you would prefer to build the package manually and just upload it using uploader you can ignore the build.
+This will upload `lambda_function.zip` file.
+```shell
+lambda-uploader --no-build
+```

--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -29,7 +29,7 @@ REQUIRED_VPC_PARAMS = {u'subnets': list, u'security_groups': list}
 DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
                   u'alias': None, u'alias_description': None,
                   u'ignore': [], u'extra_files': [], u'vpc': None,
-                  u's3_bucket': None, u's3_key': None}
+                  u's3_bucket': None, u's3_key': None, u'runtime': 'python2.7'}
 
 
 class Config(object):
@@ -84,6 +84,10 @@ class Config(object):
         self._config['alias'] = alias
         self._config['alias_description'] = description
         self._config['publish'] = True
+
+    '''Set the runtime '''
+    def set_runtime(self, runtime):
+        self._config['runtime'] = runtime
 
     '''Set all defaults after loading the config'''
     def _set_defaults(self):

--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -49,6 +49,11 @@ def build_package(path, requires, virtualenv=None, ignore=[],
     return pkg
 
 
+def create_package(path, zipfile_name=ZIPFILE_NAME):
+    pkg = Package(path, zipfile_name)
+    return pkg
+
+
 class Package(object):
     def __init__(self, path, zipfile_name=ZIPFILE_NAME):
         self._path = path

--- a/lambda_uploader/package.py
+++ b/lambda_uploader/package.py
@@ -36,6 +36,7 @@ ZIPFILE_NAME = 'lambda_function.zip'
 
 def build_package(path, requires, virtualenv=None, ignore=[],
                   extra_files=[], zipfile_name=ZIPFILE_NAME):
+    '''Builds the zip file and creates the package with it'''
     pkg = Package(path, zipfile_name)
 
     if extra_files:
@@ -50,6 +51,7 @@ def build_package(path, requires, virtualenv=None, ignore=[],
 
 
 def create_package(path, zipfile_name=ZIPFILE_NAME):
+    '''Creates the package with already existing zip file'''
     pkg = Package(path, zipfile_name)
     return pkg
 

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -62,15 +62,18 @@ def _execute(args):
         # build and include virtualenv, the default
         venv = None
 
-    _print('Building Package')
-    requirements = cfg.requirements
-    if args.requirements:
-        requirements = path.abspath(args.requirements)
-    extra_files = cfg.extra_files
-    if args.extra_files:
-        extra_files = args.extra_files
-    pkg = package.build_package(pth, requirements,
-                                venv, cfg.ignore, extra_files)
+    if args.no_build:
+        pkg = package.create_package(pth)
+    else:
+        _print('Building Package')
+        requirements = cfg.requirements
+        if args.requirements:
+            requirements = path.abspath(args.requirements)
+        extra_files = cfg.extra_files
+        if args.extra_files:
+            extra_files = args.extra_files
+        pkg = package.build_package(pth, requirements,
+                                    venv, cfg.ignore, extra_files)
 
     if not args.no_clean:
         pkg.clean_workspace()
@@ -156,6 +159,9 @@ def main(arv=None):
                         default='lambda.json')
     parser.add_argument('function_dir', default=getcwd(), nargs='?',
                         help='lambda function directory')
+    parser.add_argument('--no-build', dest='no_build',
+                        action='store_const', help='dont build the sourcecode',
+                        const=True)
 
     verbose = parser.add_mutually_exclusive_group()
     verbose.add_argument('-V', dest='loglevel', action='store_const',

--- a/lambda_uploader/uploader.py
+++ b/lambda_uploader/uploader.py
@@ -104,7 +104,7 @@ class PackageUploader(object):
         LOG.debug('running create_function_code')
         response = self._lambda_client.create_function(
             FunctionName=self._config.name,
-            Runtime='python2.7',
+            Runtime=self._config.runtime,
             Handler=self._config.handler,
             Role=self._config.role,
             Code=code,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,10 @@ def test_invalid_config_missing_function_dir2():
             # valid config file
             path.join(EX_CONFIG, 'lambda.json')
         )
+
+def test_default_runtime():
+    cfg = config.Config(EX_CONFIG)
+    assert cfg.runtime == 'python2.7'
+
+    cfg.set_runtime('java8')
+    assert cfg.runtime == 'java8'


### PR DESCRIPTION
New option `--no-build` that allows to skip building the package and new config files to specify function runtime. Can be used to upload non-python functions. For example:
```
{
  "name": "trigger",
  "runtime": "java8",
  "description": "Triggers articles extraction",
  "region": "eu-west-1",
  "handler": "com.keendly.trigger.LambdaHandler::handleRequest",
  "role": "arn:aws:iam::xxxxxxxx:role/lambda_s3_exec_role",
  "timeout": 60,
  "memory": 256
} 
```
together with ```lambda-uploader --no-build``` will take `lambda_function.zip` from project directory and upload as `java` function.
By default the runtime is set to `python2.7` so the change is fully backwards compatible.