### PR TITLE
Added --variables as arguments

### DIFF
--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -34,12 +34,14 @@ DEFAULT_PARAMS = {u'requirements': [], u'publish': False,
 
 
 class Config(object):
-    def __init__(self, pth, config_file=None, role=None):
+    def __init__(self, pth, config_file=None, role=None, variables=None):
         self._path = pth
         self._config = None
         self._load_config(config_file)
         if role is not None:
             self._config['role'] = role
+        if variables is not None:
+            self._config['variables'] = json.loads(variables)
         self._set_defaults()
         if self._config['vpc']:
             self._validate_vpc()

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -47,7 +47,8 @@ def _print(txt):
 def _execute(args):
     pth = path.abspath(args.function_dir)
 
-    cfg = config.Config(pth, args.config, role=args.role)
+    cfg = config.Config(pth, args.config, role=args.role,
+                        variables=args.variables)
 
     if args.s3_bucket:
         cfg.set_s3(args.s3_bucket, args.s3_key)
@@ -140,6 +141,8 @@ def main(arv=None):
                         default=getenv('LAMBDA_UPLOADER_ROLE'),
                         help=('IAM role to assign the lambda function, '
                               'can be set with $LAMBDA_UPLOADER_ROLE'))
+    parser.add_argument('--variables', dest='variables',
+                        help='add environment variables')
     parser.add_argument('--profile', dest='profile',
                         help='specify AWS cli profile')
     parser.add_argument('--requirements', '-r', dest='requirements',


### PR DESCRIPTION
Hello,

We access secrets via environment variables. That means we can't add it to lambda.json, this PR address this issue by passing it as an arguments.

Example:

```
lambda-uploader --variables='{"test": "test"}'
```