### PR TITLE
bump versions of boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import re
 from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = [
-    'boto3>=1.4.1',
-    'botocore>=1.4.76',
+    'boto3>=1.4.2',
+    'botocore>=1.4.85',
     'virtualenv',
 ]
 


### PR DESCRIPTION
Step functions are introduced in 1.4.2 of boto3. Bumping these versions should allow users to easily deploy lambda via lambda uploaded and step functions via other means in ci in the same environment. 