### PR TITLE
Return empty arrays in VpcConfig instead of empty config

### DIFF
--- a/lambda_uploader/uploader.py
+++ b/lambda_uploader/uploader.py
@@ -208,7 +208,10 @@ class PackageUploader(object):
                 'SecurityGroupIds': self._config.raw['vpc']['security_groups']
             }
         else:
-            return {}
+            return {
+                'SubnetIds': [],
+                'SecurityGroupIds': [],
+            }
 
     def _upload_s3(self, zip_file):
         '''


### PR DESCRIPTION
Fixes #130 

[Per AWS](https://forums.aws.amazon.com/thread.jspa?messageID=760901&threadID=246719&tstart=0), it appears that a regression was introduced to the Lambda API that is causing (intermittent?) upload failures if `VpcConfig` is `{}`. The workaround suggested by AWS is to use empty arrays instead of just an empty config. This should fix the problem until AWS fixes the API issue.
