### PR TITLE
allow for copying symlinks when copying tree to create zip

### DIFF
--- a/lambda_uploader/utils.py
+++ b/lambda_uploader/utils.py
@@ -51,7 +51,11 @@ def copy_tree(src, dest, ignore=None, include_parent=False):
                 os.makedirs(pkg_path)
 
             LOG.debug("Copying %s to %s" % (path, pkg_path))
-            shutil.copy(path, pkg_path)
+            if os.path.islink(path):
+                linkto = os.readlink(path)
+                os.symlink(linkto, os.path.join(pkg_path, filename))
+            else:
+                shutil.copy(path, pkg_path)
 
 
 # Iterate through every item in ignore

--- a/lambda_uploader/utils.py
+++ b/lambda_uploader/utils.py
@@ -53,7 +53,7 @@ def copy_tree(src, dest, ignore=None, include_parent=False):
             LOG.debug("Copying %s to %s" % (path, pkg_path))
             if os.path.islink(path):
                 linkto = os.readlink(path)
-                os.symlink(linkto, os.path.join(pkg_path, filename))
+                os.symlink(linkto.replace(src, dest, 1), os.path.join(pkg_path, filename))
             else:
                 shutil.copy(path, pkg_path)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,25 @@ def test_copy_tree():
     rmtree(TESTING_TEMP_DIR)
     rmtree(copy_dir)
 
+def test_copy_tree_with_symlink():
+    os.mkdir(TESTING_TEMP_DIR)
+    filename = 'foo.py'
+    symlink_filename = "sym-{}".format(filename)
+    with open(path.join(TESTING_TEMP_DIR, filename), 'w') as tfile:
+        tfile.write(filename)
+    os.symlink(path.join(TESTING_TEMP_DIR,filename), path.join(TESTING_TEMP_DIR,symlink_filename))
+    copy_dir = '.copy_of_test'
+
+    utils.copy_tree(TESTING_TEMP_DIR, copy_dir)
+
+    assert os.path.islink(path.join(copy_dir,symlink_filename))
+    linkto = os.readlink(path.join(copy_dir,symlink_filename))
+    assert linkto == path.join(copy_dir, filename)
+
+    rmtree(TESTING_TEMP_DIR)
+    rmtree(copy_dir)
+
+
 
 def test_ignore_file():
     ignored = utils._ignore_file('ignore/foo.py', TEST_IGNORE)


### PR DESCRIPTION
To reproduce the bug create a symlink in the root of your project and you should see  shutil.copy(path, pkg_path)(line 54 pre this commit)   failing with a "no such file or directory" error.