### PR TITLE
Add functionality for Kinesis subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ function inside a specific VPC, make sure you set up the role correctly to allow
 
 Note also the `ignore` entry is an array of regular expression strings
 used to match against the relative paths - be careful to quote accordingly.
-For example, a traditional `*.txt` "glob" is matched by the JSON string: 
+For example, a traditional `*.txt` "glob" is matched by the JSON string:
 `".*\\.txt$"` (or just `"\\.txt$"`).
 
 Example `lambda.json` file:
@@ -56,6 +56,30 @@ Example `lambda.json` file:
   }
 }
 ```
+
+You can also optionally setup a subscription to a Kinesis stream for your
+lambda using the `subscription` field as in the following sample configuration.
+
+```json
+{
+  "name": "myFunction",
+  "description": "It does things",
+  "region": "us-east-1",
+  "runtime": "python2.7",
+  "handler": "function.lambda_handler",
+  "role": "arn:aws:iam::00000000000:role/lambda_basic_execution",
+  "requirements": ["pygithub"],
+  "timeout": 30,
+  "memory": 512,
+  "subscription": {
+    "kinesis": {
+      "stream": "arn:aws:kinesis:eu-west-1:000000000000:stream/services",
+      "batch_size": 10
+    }
+  }
+}
+```
+
 
 ### Command Line Usage
 To package and upload simply run the command from within your lambda directory or

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -23,7 +23,7 @@ import traceback
 import lambda_uploader
 
 from os import getcwd, path, getenv
-from lambda_uploader import package, config, uploader
+from lambda_uploader import package, config, uploader, subscribers
 from boto3 import __version__ as boto3_version
 from botocore import __version__ as botocore_version
 
@@ -103,6 +103,10 @@ def _execute(args):
         # If the alias was set create it
         if create_alias:
             upldr.alias()
+
+        if cfg.subscription:
+            _print('Creating subscription')
+            subscribers.create_subscriptions(cfg, args.profile)
 
         pkg.clean_zipfile()
 

--- a/lambda_uploader/subscribers.py
+++ b/lambda_uploader/subscribers.py
@@ -1,0 +1,65 @@
+# Copyright 2015-2016 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import boto3
+import botocore
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class KinesisSubscriber(object):
+    ''' Invokes the lambda function on events from the Kinesis streams '''
+    def __init__(self, config, profile_name,
+                 function_name, stream_name, batch_size):
+        self._aws_session = boto3.session.Session(region_name=config.region,
+                                                  profile_name=profile_name)
+        self._lambda_client = self._aws_session.client('lambda')
+        self.function_name = function_name
+        self.stream_name = stream_name
+        self.batch_size = batch_size
+
+    def subscribe(self):
+        ''' Subscribes the lambda to the Kinesis stream '''
+        try:
+            LOG.debug('Creating Kinesis subscription')
+            self._lambda_client \
+                .create_event_source_mapping(EventSourceArn=self.stream_name,
+                                             FunctionName=self.function_name,
+                                             BatchSize=self.batch_size,
+                                             StartingPosition='TRIM_HORIZON')
+            LOG.debug('Subscription created')
+        except botocore.exceptions.ClientError as ex:
+            response_code = ex.response['Error']['Code']
+            if response_code == 'InvalidParameterValueException':
+                LOG.debug('Retrying subscription')
+                time.sleep(3)
+            elif response_code == 'ResourceConflictException':
+                LOG.debug('Subscription exists')
+            else:
+                LOG.error('Subscription failed, error=%s' % str(ex))
+                raise ex
+
+
+def create_subscriptions(config, profile_name):
+    ''' Adds supported subscriptions '''
+    if 'kinesis' in config.subscription.keys():
+        data = config.subscription['kinesis']
+        function_name = config.name
+        stream_name = data['stream']
+        batch_size = data['batch_size']
+        s = KinesisSubscriber(config, profile_name,
+                              function_name, stream_name, batch_size)
+        s.subscribe()

--- a/lambda_uploader/subscribers.py
+++ b/lambda_uploader/subscribers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import boto3
 import botocore
 import logging
@@ -43,10 +42,7 @@ class KinesisSubscriber(object):
             LOG.debug('Subscription created')
         except botocore.exceptions.ClientError as ex:
             response_code = ex.response['Error']['Code']
-            if response_code == 'InvalidParameterValueException':
-                LOG.debug('Retrying subscription')
-                time.sleep(3)
-            elif response_code == 'ResourceConflictException':
+            if response_code == 'ResourceConflictException':
                 LOG.debug('Subscription exists')
             else:
                 LOG.error('Subscription failed, error=%s' % str(ex))

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ TEST_REQUIRES = [
     'coverage>=4.0.3',
     'pytest>=2.9.1',
     'moto>=0.4.23',
+    'mock',
+    'nose',
 ]
 
 

--- a/tests/configs/lambda-with-subscription.json
+++ b/tests/configs/lambda-with-subscription.json
@@ -1,0 +1,29 @@
+{
+  "name": "myFunc",
+  "description": "myfunc",
+  "region": "us-east-1",
+  "handler": "function.lambda_handler",
+  "role": "arn:aws:iam::00000000000:role/lambda_basic_execution",
+  "requirements": ["Jinja2==2.8"],
+  "ignore": [
+    "circle.yml",
+    ".git",
+    "/*.pyc"
+  ],
+  "timeout": 30,
+  "memory": 512,
+  "subscription": {
+    "kinesis": {
+      "stream": "arn:aws:kinesis:eu-west-1:000000000000:stream/services",
+      "batch_size": 10
+    }
+  },
+  "vpc": {
+    "subnets": [
+      "subnet-00000000"
+    ],
+    "security_groups": [
+      "sg-00000000"
+    ]
+  }
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,16 @@ def test_no_vpc():
     assert cfg.raw['vpc'] is None
 
 
+def test_kinesis_subscription():
+    ksub = {
+        'stream': 'arn:aws:kinesis:eu-west-1:000000000000:stream/services',
+        'batch_size': 10
+    }
+    cfg = config.Config(EX_CONFIG, EX_CONFIG + '/lambda-with-subscription.json')
+    assert cfg.raw['subscription']['kinesis']['stream'] == ksub['stream']
+    assert cfg.raw['subscription']['kinesis']['batch_size'] == ksub['batch_size']
+
+
 def test_set_publish():
     cfg = config.Config(EX_CONFIG)
     # Check that we default to false

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -1,0 +1,23 @@
+from os import path
+from mock import patch, Mock
+import nose.tools as nt
+
+from lambda_uploader import subscribers, config
+
+
+EX_CONFIG = path.normpath(path.join(path.dirname(__file__),
+                          '../tests/configs'))
+
+class TestKinesisSubscriber(object):
+
+    @patch('lambda_uploader.subscribers.boto3.session.Session')
+    def test_successfully_adds_kinesis_subscription(self, mocked_session):
+        _mocked_lambda = Mock()
+        _mocked_session = Mock()
+        _mocked_session.client = Mock()
+        _mocked_session.client.return_value = _mocked_lambda
+        mocked_session.return_value = _mocked_session
+        conf = config.Config(path.dirname(__file__),
+                             config_file=path.join(EX_CONFIG, 'lambda-with-subscription.json'))
+        subscribers.create_subscriptions(conf, None)
+        nt.assert_equals(True, _mocked_lambda.create_event_source_mapping.called)


### PR DESCRIPTION
This PR adds functionality for the lambda to subscribe to a Kinesis stream. The configuration is defined in the field `subscription` as follows:

```json
{
  "name": "myFunc",
  "description": "myfunc",
  "region": "us-east-1",
  "handler": "function.lambda_handler",
  "role": "arn:aws:iam::00000000000:role/lambda_basic_execution",
  "requirements": ["Jinja2==2.8"],
  "ignore": [
    "circle.yml",
    ".git",
    "/*.pyc"
  ],
  "timeout": 30,
  "memory": 512,
  "subscription": {
    "kinesis": {
      "stream": "arn:aws:kinesis:eu-west-1:000000000000:stream/services",
      "batch_size": 10
    }
  },
  "vpc": {
    "subnets": [
      "subnet-00000000"
    ],
    "security_groups": [
      "sg-00000000"
    ]
  }
}
```

It also allows for the possibility to add other kinds of subscriptions, for example AWS SNS.


**My use-case:**

I'd like my lambda to process logs from a Kinesis stream, transform it into events that can be sent to Riemann for monitoring purposes. Therefore, after creating and uploading the lambda function, I need it to subscribe onto the stream to receive incoming data and process them.