### PR TITLE
Change default config file location to "function directory/lambda.json"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ python setup.py install
 
 ### Configuration File
 The lambda uploader expects a directory with, at a minimum, your lambda function
-and a `lambda.json` file.  It is not necessary to set requirements in your config
-file since the lambda uploader will also check for and use a requirements.txt file.
+and a `lambda.json` configuration file in the same directory.  It is not necessary to set
+requirements in your config file since the lambda uploader will also check for and use a
+requirements.txt file.
 
 Please note that you can leave the `vpc` object out of your config if you want your
 lambda function to use your default VPC and subnets. If you wish to use your lambda

--- a/lambda_uploader/config.py
+++ b/lambda_uploader/config.py
@@ -156,7 +156,7 @@ class Config(object):
         if not path.isdir(self._path):
             raise Exception("%s not a valid function directory" % self._path)
 
-        if not lambda_file:
+        if lambda_file:
             lambda_file = path.join(self._path, 'lambda.json')
 
         if not path.isfile(lambda_file):

--- a/lambda_uploader/shell.py
+++ b/lambda_uploader/shell.py
@@ -170,7 +170,7 @@ def main(arv=None):
                         help='Key name of the lambda function s3 object',
                         default=None)
     parser.add_argument('--config', '-c', help='Overrides lambda.json',
-                        default='lambda.json')
+                        default=None)
     parser.add_argument('function_dir', default=getcwd(), nargs='?',
                         help='lambda function directory')
     parser.add_argument('--no-build', dest='no_build',


### PR DESCRIPTION
Previously, without providing config file with -_-config_ argument, lambda-uploader would look for the config file in the directory where it was executed, not the function directory.

This behavior is not clearly stated in the README. The example also stores the config file and function in the same directory. Calling lambda-uploader from the root directory of the repository - `lambda-uploader example` - will raise an exception _"lambda.json not a valid configuration file"_. Moreover, the if condition [`_load_config` in `Config._load_config`](https://github.com/rackerlabs/lambda-uploader/blob/master/lambda_uploader/config.py#L159) can never be true because the default for the -_-config_ argument is  _'lamba.json'_.

This commit modifies the default config location to _"function directory/lambda.json"_ to follow the expected behavior.