### PR TITLE
Add py36 to envlist in tox.ini

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install -U pip
     - pip install -U tox tox-pyenv
-    - pyenv local 2.7.10 3.4.3 3.5.0
+    - pyenv local 2.7.10 3.4.3 3.6.1
 
 test:
   override:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,style
+envlist = py27,py34,py36,style
 
 [testenv]
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
Since Lambda supports Python 3.6, I thought it better to test it with 3.6