### PR TITLE
fixed ResourceConflictException when Uploading

### DIFF
--- a/lambda_uploader/uploader.py
+++ b/lambda_uploader/uploader.py
@@ -61,6 +61,11 @@ class PackageUploader(object):
             )
         LOG.debug("AWS update_function_code response: %s"
                   % conf_update_resp)
+
+        waiter = self._lambda_client.get_waiter('function_updated')
+        LOG.debug("Waiting for lambda function to be updated")
+        waiter.wait(FunctionName=self._config.name)
+
         LOG.debug('running update_function_configuration')
         response = self._lambda_client.update_function_configuration(
             FunctionName=self._config.name,


### PR DESCRIPTION
when I Upload My Function to Lambda, following Exception Occured.

```
botocore.errorfactory.ResourceConflictException: An error occurred (ResourceConflictException) when calling the UpdateFunctionConfiguration operation: The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:region:account_id:function:my_function
```

This may be due to a change in the lambda specification.
https://aws.amazon.com/jp/blogs/compute/tracking-the-state-of-lambda-functions/

so I Trying to fix this issue. Just Added `waiter` for `upload.py`.
Please Review this 🙏 